### PR TITLE
Give GifDecoder*.h a unique name to avoid Arduino ResolveLibrary picking the wrong Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This example has been deeply modified from https://github.com/prenticedavid/Anim
 
 Original Credits (see also other readme)
 
-Set DEBUG to 0, 2, 3 in GifDecoderImpl.h  
+Set GIF_DEBUG to 0, 2, 3 in Arcada_GifDecoder_Impl.h  
 
 GIF optimisation via PC or online is not that clever.   
 They should minimise the display rectangle to only cover animation changes.

--- a/examples/ArcadaAnimatedGIFs/ArcadaAnimatedGIFs.ino
+++ b/examples/ArcadaAnimatedGIFs/ArcadaAnimatedGIFs.ino
@@ -1,7 +1,7 @@
 // please read credits at the bottom of file
 
 #include <Adafruit_Arcada.h>
-#include "GifDecoder.h"
+#include <Arcada_GifDecoder.h>
 
 //#define SERVOPIN 3   // uncomment to use a servo at the same time
 #ifdef SERVOPIN

--- a/examples/crankyGIFs/crankyGIFs.ino
+++ b/examples/crankyGIFs/crankyGIFs.ino
@@ -1,7 +1,7 @@
 // please read credits at the bottom of file
 
 #include <Adafruit_Arcada.h>
-#include "GifDecoder.h"
+#include <Arcada_GifDecoder.h>
 
 // Rotary encoder hardware connected on FeatherWing
 #define PIN_ENCODER_SWITCH 5

--- a/src/Arcada_GifDecoder.h
+++ b/src/Arcada_GifDecoder.h
@@ -178,7 +178,7 @@ private:
                            0x0FFF, 0x1FFF, 0x3FFF, 0x7FFF, 0xFFFF};
 };
 
-#include "GifDecoder_Impl.h"
+#include "Arcada_GifDecoder_Impl.h"
 #include "LzwDecoder_Impl.h"
 
 #endif

--- a/src/Arcada_GifDecoder_Impl.h
+++ b/src/Arcada_GifDecoder_Impl.h
@@ -35,7 +35,7 @@
 #include "application.h"
 #endif
 
-#include "GifDecoder.h"
+#include "Arcada_GifDecoder.h"
 
 #if GIFDEBUG == 1
 #define DEBUG_SCREEN_DESCRIPTOR 1
@@ -59,8 +59,6 @@
 #define DEBUG_WAIT_FOR_KEY_PRESS 0
 
 #endif
-
-#include "GifDecoder.h"
 
 // Error codes
 #define ERROR_NONE 0

--- a/src/GifDecoder.cpp
+++ b/src/GifDecoder.cpp
@@ -1,1 +1,0 @@
-#include "GifDecoder.h"

--- a/src/LzwDecoder_Impl.h
+++ b/src/LzwDecoder_Impl.h
@@ -36,8 +36,6 @@
 #include "application.h"
 #endif
 
-#include "GifDecoder.h"
-
 template <int maxGifWidth, int maxGifHeight, int lzwMaxBits>
 void GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits>::lzw_setTempBuffer(
     uint8_t *tempBuffer) {


### PR DESCRIPTION
@ladyada turned the AnimatedGIFs sketch I maintain into a GifDecoder Library, made a bunch of improvements (awesome!), then made the library Arcada specific.  I'm going to be releasing a generic version of the Library.  To avoid Arcada GifDecoder users accidentally including the generic GifDecoder Library and vice versa, one of us should choose a new header file name so Arduino ResolveLibrary doesn't have to guess.

I propose the Arcada-specific Library should have a Arcada-specific header file name.  If you'd prefer that I came up with a unique name for the generic GifDecoder Library, I'm willing to do that instead (but I don't think it makes sense).

I cleaned up a couple things at the same time:

- the .cpp file is unnecessary as far as I can tell
- there were a couple of unnecessary `#include`s

(BTW I considered the possibility of merging our libraries, so your Arcada-specific examples would live in the generic GifDecoder Library.  I don't think you'll want to do that, as you have your Travis CI functionality that I'm sure you'll want to keep, and Arcada Library dependence to make it easier for users to download all the libraries and compile your examples.  It should be easy to share bug fixes and improvements between the two repos, as they are nearly identical except for the examples folder.  I'll be submitting PRs for a couple bug fixes after we agree on this PR, but if you want to take a look: https://github.com/pixelmatix/AnimatedGIFs/tree/library)

I don't have any Arcada-capable hardware, but I did make sure both example sketches compile with my changes.