### PR TITLE
Two bug fixes

### DIFF
--- a/src/Arcada_GifDecoder_Impl.h
+++ b/src/Arcada_GifDecoder_Impl.h
@@ -910,8 +910,10 @@ void GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits>::
           (disposalMethod == DISPOSAL_BACKGROUND) ? -1 : transparentColorIndex;
       ;
       if (drawLineCallback) {
+#if defined(USE_PALETTE565)
         (*drawLineCallback)(xofs, line + tbiImageY, imageBuf + xofs, wid,
                             palette565, skip);
+#endif
       } else if (drawPixelCallback) {
         for (int x = 0; x < wid; x++) {
           uint8_t pixel = imageBuf[x + xofs];

--- a/src/Arcada_GifDecoder_Impl.h
+++ b/src/Arcada_GifDecoder_Impl.h
@@ -900,8 +900,10 @@ void GifDecoder<maxGifWidth, maxGifHeight, lzwMaxBits>::
       //            maxGifWidth : 0; int ofs = tbiImageX - align; uint8_t *dst =
       //            (ofs < 0) ? imageBuf : imageBuf + ofs; align = (ofs < 0) ?
       //            -ofs : 0; int align = 0;
-      int len = lzw_decode(imageBuf + tbiImageX, tbiWidth,
-                           imageBuf + maxGifWidth - 1); //, align);
+      lzw_decode(imageBuf + tbiImageX, tbiWidth,
+                           imageBuf + maxGifWidth); //, align);
+      //int len = lzw_decode(imageBuf + tbiImageX, tbiWidth,
+      //                     imageBuf + maxGifWidth); //, align);
       // if (len != tbiWidth)
       //    Serial.println(len);
       int xofs = (disposalMethod == DISPOSAL_BACKGROUND) ? 0 : tbiImageX;


### PR DESCRIPTION
One bug fix doesn't affect Arcada at all, as it only applies when `USE_PALETTE565` is disabled

The other fixes an issue where the right column of pixels is glitchy.  It's very visible when used with SmartMatrix Library.  I think the bug would be visible with Arcada as well, so I'm surprised it's not fixed already.  I don't have Arcada hardware to test on, but I think I'll order a PyGamer board so I can better keep our GifDecoder Libraries in sync.
